### PR TITLE
Fix staging deployment workflow double-trigger issue

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,9 +3,6 @@ name: Deploy to Staging Environment
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
-    types: [closed]
 
 env:
   AWS_REGION: us-east-1
@@ -15,7 +12,7 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    if: github.event_name == 'push'
 
     steps:
       - name: Checkout code
@@ -53,7 +50,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: test
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    if: github.event_name == 'push'
     environment: staging
 
     steps:


### PR DESCRIPTION
Remove pull_request trigger that was causing duplicate deployments:
- When PR merged to main: triggered once for PR closed + once for push to main
- Now only triggers on push to main branch

This prevents feature branches from attempting staging deployments
and eliminates duplicate deployments when merging PRs.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
