### PR TITLE
added project id

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -59,7 +59,7 @@ jobs:
         sam deploy \
           --template-file .aws-sam/build/template.yaml \
           --stack-name ${{ env.STACK_NAME }} \
-          --parameter-overrides Environment=dev \
+          --parameter-overrides Environment=dev GoogleProjectId=dog-parking-1fcde \
           --capabilities CAPABILITY_IAM \
           --region ${{ env.AWS_REGION }} \
           --no-fail-on-empty-changeset \

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -95,7 +95,7 @@ jobs:
             sam deploy \
               --template-file .aws-sam/build/template.yaml \
               --stack-name ${{ env.STACK_NAME }} \
-              --parameter-overrides Environment=staging \
+              --parameter-overrides Environment=staging GoogleProjectId=dog-parking-1fcde \
               --capabilities CAPABILITY_IAM \
               --region ${{ env.AWS_REGION }} \
               --no-fail-on-empty-changeset \


### PR DESCRIPTION
This pull request updates the deployment workflows to include the `GoogleProjectId` parameter when deploying to both the development and staging environments. This ensures that the required Google Cloud project ID is passed to the AWS SAM deployment process.

Deployment workflow updates:

* [`.github/workflows/deploy-dev.yml`](diffhunk://#diff-6437260bac3153131c87371ba3b15180e0e07bb9a3e0ee6f7c25068aa9bdccdfL62-R62): Added `GoogleProjectId=dog-parking-1fcde` to the `--parameter-overrides` argument for development environment deployments.
* [`.github/workflows/deploy-staging.yml`](diffhunk://#diff-98b468326a86981405fb6e13c66ea8cd0032c4c7e4f2816fbc42a1fa9b32e991L98-R98): Added `GoogleProjectId=dog-parking-1fcde` to the `--parameter-overrides` argument for staging environment deployments.